### PR TITLE
Changed to proper componentFactoryResolver methods for ng2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,18 @@
     "prepublish": "npm run test && npm run build"
   },
   "devDependencies": {
-    "@angular/http": "2.0.0-rc.3",
-    "@angular/common": "2.0.0-rc.3",
-    "@angular/compiler": "2.0.0-rc.3",
-    "@angular/forms": "~0.1.1",
-    "@angular/core": "2.0.0-rc.3",
-    "@angular/platform-browser": "2.0.0-rc.3",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.3",
-    "@angular/platform-server": "2.0.0-rc.3",
-    "@angular/router": "3.0.0-alpha.7",
+    "@angular/http": "2.0.0",
+    "@angular/common": "2.0.0",
+    "@angular/compiler": "2.0.0",
+    "@angular/forms": "2.0.0",
+    "@angular/core": "2.0.0",
+    "@angular/platform-browser": "2.0.0",
+    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/platform-server": "2.0.0",
+    "@angular/router": "3.0.0",
 
     "core-js": "^2.4.0",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.12",
     "zone.js": "~0.6.12",
 
     "es6-promise": "^3.1.2",
@@ -42,7 +42,7 @@
     "tslint": "^3.5.0",
     "ts-helpers": "1.1.1",
     "typescript": "^1.9.0-dev.20160409",
-    "typings": "~1.0.3"
+    "typings": "~1.4.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angularclass/webpack-toolkit",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": "Partick Stapleton <patrick@angularclass.com>",
   "description": "Webpack helpers for Angular 2 by AngularClass",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,10 @@ export class WebpackComponentResolver {
       return this._webpackAsyncModules.fetch(componentType)
         .then(cmpFile => {
           let component = this._resolveExports(cmpFile, componentType);
-          return this._resolver.resolveComponent(component);
+          return this._resolver.resolveComponentFactory(component);
         });
     }
-    return this._resolver.resolveComponent(componentType);
+    return this._resolver.resolveComponentFactory(componentType);
   }
 
   clearCache(): void {}


### PR DESCRIPTION
The `resolveComponent` method is unavailable for the `componentFactoryResolver` - changed to `resolveComponentFactory`
Also required some updates to the `package.json`, since we are not using the rc modules anymore. Also, updated the typings while at it. Seems to work at least for me - everyone else 
